### PR TITLE
docs: fix usage with vim.pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,11 +312,20 @@ require("lz.n").load {
   -- Make sure you add lz.n first.
   vim.pack.add({ "https://github.com/nvim-neorocks/lz.n" })
 
+  ---@param spec lz.n.PackPluginData
+  local function wrapped_load(plug)
+    return require("lz.n").load(plug.spec)
+  end
+
+  ---@class PlugSpec : vim.pack.Spec
+  ---@field data? lz.n.PluginLoadSpec
+
   -- You can inject lz.n.PluginSpec fields (without the name) via the
   -- `data` field.
 
-  ---@type lz.n.pack.Spec[]
+  ---@type (string|PlugSpec)[]
   local plugins = {
+    "https://github.com/neovim/nvim-lspconfig",
     {
       src = "https://github.com/nvim-telescope/telescope.nvim",
       data = {
@@ -333,7 +342,7 @@ require("lz.n").load {
 
   --- Add the plugins, replacing the built-in `load` function
   --- with lz.n's implementation.
-  vim.pack.add(plugins, { load = require("lz.n").load })
+  vim.pack.add(plugins, { load = wrapped_load })
   ```
 
   Note: Until [neovim/#35550](https://github.com/neovim/neovim/issues/35550)


### PR DESCRIPTION
## Summary

- modify usage with neovim's builtin plugin manager to work well

## Background

When I was trying to use this plugin with Neovim's builtin plugin manager, following the documents, I got error.

- minimal config
```lua
vim.pack.add({"https://github.com/nvim-neorocks/lz.n"})

local plugins = {
  "https://github.com/neovim/nvim-lspconfig",
}

vim.pack.add(plugins, { load = require("lz.n").load })
```

- error message
```
Error in /Users/mild/.config/nvim_mild/init.lua:
E5113: Lua chunk: .../neovim/HEAD-79bfeec/share/nvim/runtime/lua/vim/pack.lua:755: vim.pack:

`nvim-lspconfig`:
...hare/nvim_mild/site/pack/core/opt/lz.n/lua/lz/n/spec.lua:132: unable to normalize plugin spec: {
  path = "/Users/mild/.local/share/nvim_mild/site/pack/core/opt/nvim-lspconfig",
  spec = {
    name = "nvim-lspconfig",
    src = "https://github.com/neovim/nvim-lspconfig"
  }
}
```

The cause is lz.n loader expects the given argument is `lz.n.PluginSpec`, while actual value is `vim.pack.Plug`.
`vim.pack.Plug` wraps `vim.pack.Spec` in its `spec` field. So I modified the function passed to pack's loader.

- lz.n spec perser source
https://github.com/nvim-neorocks/lz.n/blob/590d1fcae1c34bf7f366de87908aa990a2b555af/lua/lz/n/spec.lua#L80-L90

- neovim's plug sources

https://github.com/neovim/neovim/blob/13b04207f167b957bc8967c32d816349be024882/runtime/lua/vim/pack.lua#L284-L289

https://github.com/neovim/neovim/blob/13b04207f167b957bc8967c32d816349be024882/runtime/lua/vim/pack.lua#L706

https://github.com/neovim/neovim/blob/13b04207f167b957bc8967c32d816349be024882/runtime/lua/vim/pack.lua#L719-L732
